### PR TITLE
Bug fix: Modify quote to double quote.

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasPlugin.m
+++ b/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasPlugin.m
@@ -1244,7 +1244,7 @@ static WizCanvasPlugin * wizViewManagerInstance = NULL;
             NSString *type = [[NSString alloc] initWithString:(NSString*)[messageComponents objectAtIndex:3]];
 
             WizCanvasView *targetCanvasView = (WizCanvasView *)[viewList objectForKey:targetView];
-            NSString *js = [NSString stringWithFormat:@"wizCanvasMessenger.__triggerMessageEvent('%@', '%@', '%@', '%@');", originView, targetView, data, type];
+            NSString *js = [NSString stringWithFormat:@"wizCanvasMessenger.__triggerMessageEvent(\"%@\", \"%@\", \"%@\", \"%@\");", originView, targetView, data, type];
             [targetCanvasView evaluateScript:js];
 
             [data release];


### PR DESCRIPTION
To test, replace in www/index.html:
- l.407 by

``` JavaScript
var params = { color: "fewo\"i#eprw'jew–\wqrq\njterpwo" };
```
- l.421 by

``` JavaScript
alert(e.data.message);
```

and in www/assets/canvas/index.js:
- l.82 by:

``` JavaScript
wizCanvasMessenger.postMessage({ message: e.data.color }, "mainView");
```
