### PR TITLE
[Fix] Loading URL would sometimes fail

### DIFF
--- a/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasView.m
+++ b/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasView.m
@@ -237,7 +237,7 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 - (BOOL)loadRequest:(NSString *)url {
     NSLog(@"Loading Script: %@", url );
 
-    NSError *error;
+    NSError *error = nil;
     NSData *urlData = [NSData dataWithContentsOfURL:[NSURL URLWithString:url] options:0 error:&error];
 
     if (!urlData || error) {

--- a/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasView.m
+++ b/platforms/ios/HelloCordova/Plugins/WizCanvasPlugin/WizCanvasView.m
@@ -235,13 +235,18 @@ void EJBlockFunctionFinalize(JSObjectRef object) {
 #pragma mark Script loading and execution
 
 - (BOOL)loadRequest:(NSString *)url {
-    NSLog(@"Loading Script: %@", url );
+    NSLog(@"Loading Script: %@", url);
 
     NSError *error = nil;
     NSData *urlData = [NSData dataWithContentsOfURL:[NSURL URLWithString:url] options:0 error:&error];
 
-    if (!urlData || error) {
-        NSLog(@"Error: Can't Find Script %@", url );
+    if (error) {
+        NSLog(@"Error: Could not load the requested url %@: %@", url, [error localizedDescription]);
+        return NO;
+    }
+    
+    if (!urlData) {
+        NSLog(@"Error: No data loaded from %@", url);
         return NO;
     }
 


### PR DESCRIPTION
Initializing the error object to `nil` avoid having garbage set in the object (code 0).
When no error occur, NSData doesn't override the `error` object to nil, so it was making the following condition check to fail.

Also separated the different condition check (error, no data) to get better log.
